### PR TITLE
fix name in add_test_rss_feed script

### DIFF
--- a/add_test_rss_feed.sh
+++ b/add_test_rss_feed.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-docker ps | grep "zeeguu-api-core-test" >/dev/null
+docker ps | grep "zeeguu-api-core-dev" >/dev/null
 if [ $? -ne 0 ]; then
     echo "Zeeguu-API-Core container not found!"
     exit 1
 fi
 
-printf "http://rss.cnn.com/rss/edition_world.rss\nCNN World RSS Feed\ncnn.png\nCNN World RSS Feed for news\nen" | docker exec -i zeeguu-api-core-test python /opt/Zeeguu-API/tools/add_rssfeed.py
-docker exec -i zeeguu-api-core-test python /opt/Zeeguu-Core/tools/feed_retrieval.py
+printf "http://rss.cnn.com/rss/edition_world.rss\nCNN World RSS Feed\ncnn.png\nCNN World RSS Feed for news\nen" | docker exec -i zeeguu-api-core-dev python /opt/Zeeguu-API/tools/add_rssfeed.py
+docker exec -i zeeguu-api-core-dev python /opt/Zeeguu-Core/tools/feed_retrieval.py


### PR DESCRIPTION
fix name in add_test_rss_feed script to reflect the updated name of the docker container from 'test' to 'dev'