### PR TITLE
Expose API via apache and reverse proxy from zeeguu-web

### DIFF
--- a/docker-files-dev/zeeguu-api-core/Dockerfile
+++ b/docker-files-dev/zeeguu-api-core/Dockerfile
@@ -12,4 +12,5 @@ RUN python setup.py install
 
 WORKDIR /opt/Zeeguu-API
 
+# Running the API in debug mode
 CMD ["python", "zeeguu_api"]

--- a/docker-files-dev/zeeguu-web/Dockerfile
+++ b/docker-files-dev/zeeguu-web/Dockerfile
@@ -10,10 +10,6 @@ ARG ZEEGUU_API__EXTERNAL=http://127.0.0.1:9001
 # ZEEGUU_API__INTERNAL is accessed from the python code.
 ARG ZEEGUU_API__INTERNAL=http://127.0.0.1:9001
 
-# Enable Zeeguu-Web website
-COPY ./docker-files/zeeguu-web/apache-zeeguu.conf /etc/apache2/sites-available/apache-zeeguu.conf
-RUN a2ensite apache-zeeguu
-
 # Install Zeeguu-Web
 COPY --chown=www-data:www-data Zeeguu-Web /opt/Zeeguu-Web
 WORKDIR /opt/Zeeguu-Web
@@ -58,9 +54,16 @@ RUN cp -r /opt/Zeeguu-Web /var/www/zeeguu-web
 RUN chown www-data /var/www
 RUN chgrp www-data /var/www
 
+# Enable Zeeguu-Web website
+COPY ./docker-files/zeeguu-web/apache-zeeguu.conf /etc/apache2/sites-available/apache-zeeguu.conf
+RUN a2ensite apache-zeeguu
+
 # Disable default website and enable zeeguu
 RUN a2dissite 000-default.conf
 RUN a2ensite apache-zeeguu.conf
+
+RUN sed -i "s,http://127.0.0.1:8080/api,$ZEEGUU_API__INTERNAL,g" /etc/apache2/sites-available/apache-zeeguu.conf
+RUN sed -i "s,http://127.0.0.1:8080/api,$ZEEGUU_API__INTERNAL/,g" /opt/Zeeguu-Web/default_web.cfg
 
 # mod_wsgi will not be able to import python packages without this
 ENV PYTHONPATH=/usr/local/lib/python3.6/site-packages
@@ -74,7 +77,5 @@ ENV ZEEGUU_WEB_CONFIG=/opt/Zeeguu-Web/default_web.cfg
 # Teacher-Dashboard
 ENV TEACHER_DASHBOARD_CONFIG=/opt/Zeeguu-Teacher-Dashboard/src/default.cfg
 ENV ZEEGUU_API=$ZEEGUU_API
-
-RUN a2enmod rewrite
 
 CMD  /usr/sbin/apache2ctl -D FOREGROUND

--- a/docker-files/zeeguu-api-core/Dockerfile
+++ b/docker-files/zeeguu-api-core/Dockerfile
@@ -1,8 +1,17 @@
 FROM python:3.6
 
-# Update and install additional tools
+# Install apache2
 RUN apt-get update
-RUN apt-get install vim -y
+RUN apt-get install -y \
+    apache2 \
+    apache2-dev \
+    vim
+
+# Install an up to date wsgi
+RUN pip install mod_wsgi
+RUN /bin/bash -c 'mod_wsgi-express install-module | tee /etc/apache2/mods-available/wsgi.{load,conf}'
+RUN a2enmod wsgi
+RUN a2enmod headers
 
 # Install Zeeguu-Core
 COPY Zeeguu-Core /opt/Zeeguu-Core
@@ -11,7 +20,10 @@ RUN pip install -r requirements.txt
 RUN python setup.py install
 
 # Install Zeeguu-API
-COPY Zeeguu-API /opt/Zeeguu-API
+# Apache will run Zeeguu-API as a WSGI module. It needs to create the DB for wordsstats:
+# https://github.com/zeeguu-ecosystem/Python-Wordstats/blob/master/wordstats/config.py#L1
+# under /opt/Zeeguu-API/wordinfo.db
+COPY --chown=www-data:www-data Zeeguu-API /opt/Zeeguu-API
 WORKDIR /opt/Zeeguu-API
 RUN pip install -r requirements.txt
 RUN python setup.py install
@@ -23,6 +35,16 @@ ENV ZEEGUU_CORE_LOG_DIR=/tmp/zeeguu-core-logs
 # TODO: Check if this is still required
 # RUN python -m zeeguu.populate
 
+# Enable Zeeguu-Web website
+COPY ./docker-files/zeeguu-api-core/apache-zeeguu-api.conf /etc/apache2/sites-available/apache-zeeguu-api.conf
+# Disable default website and enable zeeguu
+RUN a2dissite 000-default.conf
+RUN a2ensite apache-zeeguu-api
+
+# Apache will listen on port 8080 for the API
+# Zeeguu-Web will forward requests from /api to this apache
+RUN sed -i "s,Listen 80,Listen 8080,g" /etc/apache2/ports.conf
+
 WORKDIR /opt/Zeeguu-API
 
-CMD ["python", "zeeguu_api"]
+CMD  /usr/sbin/apache2ctl -D FOREGROUND

--- a/docker-files/zeeguu-api-core/apache-zeeguu-api.conf
+++ b/docker-files/zeeguu-api-core/apache-zeeguu-api.conf
@@ -1,0 +1,22 @@
+# -*- apache -*-
+
+<VirtualHost *:8080>
+
+    # Zeeguu API
+    ###########
+    WSGIDaemonProcess zeeguu_api python-path=/opt/Zeeguu-API/
+    WSGIScriptAlias /api /opt/Zeeguu-API/zeeguu_api.wsgi
+    <Location /api>
+        WSGIProcessGroup zeeguu_api
+    </Location>
+
+    <Directory "/opt/Zeeguu-API">
+        <Files "zeeguu_api.wsgi">
+            Require all granted
+        </Files>
+    </Directory>
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    LogLevel info
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>

--- a/docker-files/zeeguu-web/Dockerfile
+++ b/docker-files/zeeguu-web/Dockerfile
@@ -8,7 +8,7 @@ ARG DEFAULT_ZEEGUU_API="https://zeeguu.unibe.ch/api"
 # ZEEGUU_API__EXTERNAL is accessed from the static JS client code.
 ARG ZEEGUU_API__EXTERNAL=http://127.0.0.1:9001
 # ZEEGUU_API__INTERNAL is accessed from the python code.
-ARG ZEEGUU_API__INTERNAL=http://127.0.0.1:9001
+ARG ZEEGUU_API__INTERNAL=http://127.0.0.1:8080
 
 # The ZEEGUU_API__EXTERNAL should be reachable from the client side while
 # ZEEGUU_API__INTERNAL has to be reachable from the server side.
@@ -31,10 +31,6 @@ RUN pip install mod_wsgi
 RUN /bin/bash -c 'mod_wsgi-express install-module | tee /etc/apache2/mods-available/wsgi.{load,conf}'
 RUN a2enmod wsgi
 RUN a2enmod headers
-
-# Enable Zeeguu-Web website
-COPY ./docker-files/zeeguu-web/apache-zeeguu.conf /etc/apache2/sites-available/apache-zeeguu.conf
-RUN a2ensite apache-zeeguu
 
 # All folders exposed via apache need to be owned by www-data since
 # that is the user apache will run under.
@@ -87,9 +83,14 @@ RUN cp -r /opt/Zeeguu-Web /var/www/zeeguu-web
 RUN chown www-data /var/www
 RUN chgrp www-data /var/www
 
+# Enable Zeeguu-Web website
+COPY ./docker-files/zeeguu-web/apache-zeeguu.conf /etc/apache2/sites-available/apache-zeeguu.conf
 # Disable default website and enable zeeguu
 RUN a2dissite 000-default.conf
 RUN a2ensite apache-zeeguu.conf
+
+RUN sed -i "s,http://127.0.0.1:8080,$ZEEGUU_API__INTERNAL,g" /etc/apache2/sites-available/apache-zeeguu.conf
+RUN sed -i "s,http://127.0.0.1:9001,$ZEEGUU_API__INTERNAL/api,g" /opt/Zeeguu-Web/default_web.cfg
 
 # mod_wsgi will not be able to import python packages without this
 ENV PYTHONPATH=/usr/local/lib/python3.6/site-packages
@@ -105,5 +106,7 @@ ENV TEACHER_DASHBOARD_CONFIG=/opt/Zeeguu-Teacher-Dashboard/src/default.cfg
 ENV ZEEGUU_API=$ZEEGUU_API
 
 RUN a2enmod rewrite
+RUN a2enmod proxy
+RUN a2enmod proxy_http
 
 CMD  /usr/sbin/apache2ctl -D FOREGROUND

--- a/docker-files/zeeguu-web/apache-zeeguu.conf
+++ b/docker-files/zeeguu-web/apache-zeeguu.conf
@@ -8,6 +8,13 @@ ServerName localhost
         Require all granted
     </Directory>
 
+    # Zeeguu API
+    ###########
+    ProxyPass "/api" "http://127.0.0.1:8080/api"
+    ProxyPassReverse "/api" "http://127.0.0.1:8080/api"
+    ProxyPass "/dashboard" "http://127.0.0.1:8080/api/dashboard"
+    ProxyPassReverse "/dashboard" "http://127.0.0.1:8080/api/dashboard"
+
     # Teacher Dashboard
     ###########
     WSGIDaemonProcess teacher_dash python-path=/opt/Zeeguu-Teacher-Dashboard/teacher_dashboard/teacher_dashboard/
@@ -25,15 +32,15 @@ ServerName localhost
     </Location>
 
     <Directory "/opt/Zeeguu-Web">
-            <Files "zeeguu_web.wsgi">
-                Require all granted
-            </Files>
+        <Files "zeeguu_web.wsgi">
+            Require all granted
+        </Files>
     </Directory>
 
     <Directory "/opt/Zeeguu-Teacher-Dashboard/teacher_dashboard">
-            <Files "teacherdash.wsgi">
-                Require all granted
-            </Files>
+        <Files "teacherdash.wsgi">
+            Require all granted
+        </Files>
     </Directory>
 
     <Directory /var/www/zeeguu-web/zeeguu_web/app/>


### PR DESCRIPTION
Currently the API is running in debug mode. This commit
ensures that the API will run as a WSGI module exposed
via an apache.

The Zeeguu-Web apache will act as a reverse proxy between
the clients and the API.

In development mode, the API will run in debug mode with
the python command.