### PR TITLE
Update teacher dashboard path for wsgi module

### DIFF
--- a/docker-files/zeeguu-web/apache-zeeguu.conf
+++ b/docker-files/zeeguu-web/apache-zeeguu.conf
@@ -17,8 +17,8 @@ ServerName localhost
 
     # Teacher Dashboard
     ###########
-    WSGIDaemonProcess teacher_dash python-path=/opt/Zeeguu-Teacher-Dashboard/teacher_dashboard/teacher_dashboard/
-    WSGIScriptAlias /teacher /opt/Zeeguu-Teacher-Dashboard/teacher_dashboard/teacherdash.wsgi
+    WSGIDaemonProcess teacher_dash python-path=/opt/Zeeguu-Teacher-Dashboard/src/zeeguu_teacher_dashboard/
+    WSGIScriptAlias /teacher /opt/Zeeguu-Teacher-Dashboard/src/teacherdash.wsgi
     <Location /teacher>
         WSGIProcessGroup teacher_dash
     </Location>
@@ -37,7 +37,7 @@ ServerName localhost
         </Files>
     </Directory>
 
-    <Directory "/opt/Zeeguu-Teacher-Dashboard/teacher_dashboard">
+    <Directory "/opt/Zeeguu-Teacher-Dashboard/src/">
         <Files "teacherdash.wsgi">
             Require all granted
         </Files>


### PR DESCRIPTION
Teacher dashboard is broken at the moment. The issue is that the apache.conf is still using the old path to the WSGI module which cannot be found.

This PR updates the path to the correct one.