### PR TITLE
Change log folder path

### DIFF
--- a/docker-files/zeeguu-api-core/Dockerfile
+++ b/docker-files/zeeguu-api-core/Dockerfile
@@ -63,7 +63,6 @@ RUN python -m nltk.downloader -d /var/www/nltk_data punkt
 # Set default path to config
 ENV ZEEGUU_CORE_CONFIG=/opt/Zeeguu-Core/default_core.cfg
 ENV ZEEGUU_API_CONFIG=/opt/Zeeguu-API/default_api.cfg
-ENV ZEEGUU_CORE_LOG_DIR=/opt/zeeguu-ecosystem-logs/zeeguu_core_logs
 
 
 

--- a/docker-files/zeeguu-api-core/Dockerfile
+++ b/docker-files/zeeguu-api-core/Dockerfile
@@ -63,7 +63,7 @@ RUN python -m nltk.downloader -d /var/www/nltk_data punkt
 # Set default path to config
 ENV ZEEGUU_CORE_CONFIG=/opt/Zeeguu-Core/default_core.cfg
 ENV ZEEGUU_API_CONFIG=/opt/Zeeguu-API/default_api.cfg
-ENV ZEEGUU_CORE_LOG_DIR=/tmp/zeeguu-core-logs
+ENV ZEEGUU_CORE_LOG_DIR=/opt/zeeguu-ecosystem-logs/zeeguu_core_logs
 
 
 

--- a/docker-files/zeeguu-api-core/apache-zeeguu-api.conf
+++ b/docker-files/zeeguu-api-core/apache-zeeguu-api.conf
@@ -4,7 +4,7 @@
 
     # Zeeguu API
     ###########
-    WSGIDaemonProcess zeeguu_api home=/opt/zeeguu-ecosystem-logs/ python-path=/opt/Zeeguu-API/
+    WSGIDaemonProcess zeeguu_api home=/opt/zeeguu-data/ python-path=/opt/Zeeguu-API/
     WSGIScriptAlias / /opt/Zeeguu-API/zeeguu_api.wsgi
     <Location />
         WSGIProcessGroup zeeguu_api

--- a/docker-files/zeeguu-api-core/apache-zeeguu-api.conf
+++ b/docker-files/zeeguu-api-core/apache-zeeguu-api.conf
@@ -4,7 +4,7 @@
 
     # Zeeguu API
     ###########
-    WSGIDaemonProcess zeeguu_api python-path=/opt/Zeeguu-API/
+    WSGIDaemonProcess zeeguu_api home=/opt/zeeguu-ecosystem-logs/ python-path=/opt/Zeeguu-API/
     WSGIScriptAlias / /opt/Zeeguu-API/zeeguu_api.wsgi
     <Location />
         WSGIProcessGroup zeeguu_api

--- a/docker-files/zeeguu-web/Dockerfile
+++ b/docker-files/zeeguu-web/Dockerfile
@@ -99,7 +99,7 @@ ENV PYTHONPATH=/usr/local/lib/python3.6/site-packages
 WORKDIR /opt
 
 # Zeeguu-Core
-ENV ZEEGUU_CORE_LOG_DIR=/tmp/zeeguu-core-logs
+ENV ZEEGUU_CORE_LOG_DIR=/opt/zeeguu-ecosystem-logs/zeeguu_core_logs
 # Zeeguu-Web
 ENV ZEEGUU_WEB_CONFIG=/opt/Zeeguu-Web/default_web.cfg
 # Teacher-Dashboard

--- a/docker-files/zeeguu-web/Dockerfile
+++ b/docker-files/zeeguu-web/Dockerfile
@@ -98,8 +98,6 @@ ENV PYTHONPATH=/usr/local/lib/python3.6/site-packages
 
 WORKDIR /opt
 
-# Zeeguu-Core
-ENV ZEEGUU_CORE_LOG_DIR=/opt/zeeguu-ecosystem-logs/zeeguu_core_logs
 # Zeeguu-Web
 ENV ZEEGUU_WEB_CONFIG=/opt/Zeeguu-Web/default_web.cfg
 # Teacher-Dashboard

--- a/docker-files/zeeguu-web/apache-zeeguu.conf.default
+++ b/docker-files/zeeguu-web/apache-zeeguu.conf.default
@@ -28,7 +28,7 @@
 
     # Teacher Dashboard
     ###########
-    WSGIDaemonProcess teacher_dash home=/opt/zeeguu-ecosystem-logs/ python-path=/opt/Zeeguu-Teacher-Dashboard/src/zeeguu_teacher_dashboard/
+    WSGIDaemonProcess teacher_dash home=/opt/zeeguu-data/ python-path=/opt/Zeeguu-Teacher-Dashboard/src/zeeguu_teacher_dashboard/
     WSGIScriptAlias /teacher /opt/Zeeguu-Teacher-Dashboard/src/teacherdash.wsgi
     <Location /teacher>
         WSGIProcessGroup teacher_dash
@@ -36,7 +36,7 @@
 
     # WEB 
     # ################
-    WSGIDaemonProcess zeeguu_web hhome=/opt/zeeguu-ecosystem-logs/ python-path=/opt/Zeeguu-Web/
+    WSGIDaemonProcess zeeguu_web hhome=/opt/zeeguu-data/ python-path=/opt/Zeeguu-Web/
     WSGIScriptAlias / /opt/Zeeguu-Web/zeeguu_web.wsgi
     <Location />
         WSGIProcessGroup zeeguu_web

--- a/docker-files/zeeguu-web/apache-zeeguu.conf.default
+++ b/docker-files/zeeguu-web/apache-zeeguu.conf.default
@@ -36,7 +36,7 @@
 
     # WEB 
     # ################
-    WSGIDaemonProcess zeeguu_web hhome=/opt/zeeguu-data/ python-path=/opt/Zeeguu-Web/
+    WSGIDaemonProcess zeeguu_web home=/opt/zeeguu-data/ python-path=/opt/Zeeguu-Web/
     WSGIScriptAlias / /opt/Zeeguu-Web/zeeguu_web.wsgi
     <Location />
         WSGIProcessGroup zeeguu_web

--- a/docker-files/zeeguu-web/apache-zeeguu.conf.default
+++ b/docker-files/zeeguu-web/apache-zeeguu.conf.default
@@ -28,7 +28,7 @@
 
     # Teacher Dashboard
     ###########
-    WSGIDaemonProcess teacher_dash python-path=/opt/Zeeguu-Teacher-Dashboard/src/zeeguu_teacher_dashboard/
+    WSGIDaemonProcess teacher_dash home=/opt/zeeguu-ecosystem-logs/ python-path=/opt/Zeeguu-Teacher-Dashboard/src/zeeguu_teacher_dashboard/
     WSGIScriptAlias /teacher /opt/Zeeguu-Teacher-Dashboard/src/teacherdash.wsgi
     <Location /teacher>
         WSGIProcessGroup teacher_dash
@@ -36,7 +36,7 @@
 
     # WEB 
     # ################
-    WSGIDaemonProcess zeeguu_web python-path=/opt/Zeeguu-Web/
+    WSGIDaemonProcess zeeguu_web hhome=/opt/zeeguu-ecosystem-logs/ python-path=/opt/Zeeguu-Web/
     WSGIScriptAlias / /opt/Zeeguu-Web/zeeguu_web.wsgi
     <Location />
         WSGIProcessGroup zeeguu_web


### PR DESCRIPTION
The log files will be stored by default by the containers under ``/opt/zeeguu-ecosystem-logs``
To keep the logs between container restarts or rebuilds, one has to map a folder from the host inside the container to the above path.
Example of the argument required to be passed: ``-v <path_on_host>:/opt/zeeguu-ecosystem-logs``.
The log folder on the host will look like this:
```
/zeeguu-ecosystem$ ls -lha
total 36K
drwxrwxrwx 3 alin     alin     4.0K Mar  7 21:14 .
drwxr-xr-x 6 alin     alin     4.0K Mar  7 21:12 ..
-rw-r--r-- 1 www-data www-data    0 Mar  7 21:14 errors.translators.log
-rw-r--r-- 1 www-data www-data 2.3K Mar  7 22:21 translators.log
-rw-r--r-- 1 www-data www-data  20K Mar  7 21:14 wordinfo.db
drwxr-xr-x 2 www-data www-data 4.0K Mar  7 22:17 zeeguu_core_logs
```
The folder on the host must allow file creation by any user.