### PR TITLE
Fix zeeguu-data folder

### DIFF
--- a/docker-files/zeeguu-api-core/Dockerfile
+++ b/docker-files/zeeguu-api-core/Dockerfile
@@ -78,4 +78,7 @@ RUN sed -i "s,Listen 80,Listen 8080,g" /etc/apache2/ports.conf
 
 WORKDIR /opt/Zeeguu-API
 
+# Create the zeeguu-data folder
+RUN mkdir /opt/zeeguu-data && chown www-data:www-data /opt/zeeguu-data
+
 CMD  /usr/sbin/apache2ctl -D FOREGROUND

--- a/docker-files/zeeguu-api-core/apache-zeeguu-api.conf
+++ b/docker-files/zeeguu-api-core/apache-zeeguu-api.conf
@@ -4,7 +4,7 @@
 
     # Zeeguu API
     ###########
-    WSGIDaemonProcess zeeguu_api home=/opt/zeeguu_data/ python-path=/opt/Zeeguu-API/
+    WSGIDaemonProcess zeeguu_api home=/opt/zeeguu-data/ python-path=/opt/Zeeguu-API/
     WSGIScriptAlias / /opt/Zeeguu-API/zeeguu_api.wsgi
     <Location />
         WSGIProcessGroup zeeguu_api

--- a/docker-files/zeeguu-web/Dockerfile
+++ b/docker-files/zeeguu-web/Dockerfile
@@ -98,6 +98,9 @@ ENV PYTHONPATH=/usr/local/lib/python3.6/site-packages
 
 WORKDIR /opt
 
+# Create the zeeguu-data folder
+RUN mkdir /opt/zeeguu-data && chown www-data:www-data /opt/zeeguu-data
+
 # Zeeguu-Web
 ENV ZEEGUU_WEB_CONFIG=/opt/Zeeguu-Web/default_web.cfg
 # Teacher-Dashboard


### PR DESCRIPTION
The WSGI module expects the zeeguu-data folder
to be already created and fails to start otherwise.

This commit creates the folder inside the Dockerfile.