### PR TITLE
Add missing nltk required package

### DIFF
--- a/docker-files/zeeguu-api-core/Dockerfile
+++ b/docker-files/zeeguu-api-core/Dockerfile
@@ -36,6 +36,7 @@ RUN python setup.py install
 #ML: This is needed because the translators installer installs nltk in ~ (which in the
 # case of docker is /root. however, when run, it runs as www-data with ~ being /var/www 
 RUN python -m nltk.downloader -d /var/www/nltk_data punkt
+RUN python -m nltk.downloader -d /var/www/nltk_data averaged_perceptron_tagger
 
 
 ## Installing Flask Monitoring Dashboard (FMD)


### PR DESCRIPTION
Wordnik fails because of a missing nltk package.
```
**********************************************************************
  Resource averaged_perceptron_tagger not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('averaged_perceptron_tagger')

  Attempted to load taggers/averaged_perceptron_tagger/averaged_perceptron_tagger.pickle

  Searched in:
    - '/var/www/nltk_data'
    - '/usr/local/nltk_data'
    - '/usr/local/share/nltk_data'
    - '/usr/local/lib/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/local/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/local/lib/nltk_data'
**********************************************************************
```
This patch addresses this issue by downloading the package when the docker image is built.