### PR TITLE
Fix setup_all script

### DIFF
--- a/setup_all.sh
+++ b/setup_all.sh
@@ -4,21 +4,34 @@ source config_vars.sh
 
 set -e
 
+ls config/ | grep default | while read cfgfilename; do
+    new_cfgfilename=${cfgfilename::-8}
+    cp -n config/$cfgfilename config/$new_cfgfilename
+done
+
 # Start MySQL server
 ./run_mysql.sh
 
+cd Zeeguu-API
+API_VERSION=`git log --format="%H" -n 1`
+cd ..
 # Build and run the API
-docker build -t zeeguu-api-core -f docker-files/zeeguu-api-core/Dockerfile .
+docker build --build-arg API_VERSION="$API_VERSION" -t zeeguu-api-core -f docker-files/zeeguu-api-core/Dockerfile .
 docker run --net=host -d \
     -e MICROSOFT_TRANSLATE_API_KEY="$MICROSOFT_TRANSLATE_API_KEY" \
     -e GOOGLE_TRANSLATE_API_KEY="$GOOGLE_TRANSLATE_API_KEY" \
     -e WORDNIK_API_KEY="$WORDNIK_API_KEY" \
     --name=zeeguu-api-core zeeguu-api-core
 
+cp -n docker-files/zeeguu-web/apache-zeeguu.conf.default docker-files/zeeguu-web/apache-zeeguu.conf
+
 # Build and run the Web UI
-docker build -t zeeguu-web --build-arg ZEEGUU_API__EXTERNAL="http://$SERVER_IP/api" -f docker-files/zeeguu-web/Dockerfile .
+docker build -t zeeguu-web --build-arg ZEEGUU_API__EXTERNAL="http://api.zeeguu.local" -f docker-files/zeeguu-web/Dockerfile .
 docker run --net=host -d --name=zeeguu-web zeeguu-web
 
 # Add a test RSS feed
+# English
 printf "http://rss.cnn.com/rss/edition_world.rss\nCNN World RSS Feed\ncnn.png\nCNN World RSS Feed for news\nen" | docker exec -i zeeguu-api-core python /opt/Zeeguu-API/tools/add_rssfeed.py
+# German
+printf "http://newsfeed.zeit.de/sport/index\nGerman RSS Feed\ncnn.png\nGerman feed for sports\nde" | docker exec -i zeeguu-api-core python /opt/Zeeguu-API/tools/add_rssfeed.py
 docker exec -i zeeguu-api-core python /opt/Zeeguu-Core/tools/feed_retrieval.py


### PR DESCRIPTION
Some of the latest changes are not reflected
in setup_all.sh script causing it to fail.

This commit updates the script to ensure it can
deploy a full environment without errors or
user intervention.